### PR TITLE
make code compatible with older versions of Python 3 and increase prime limit to 97

### DIFF
--- a/te_common.py
+++ b/te_common.py
@@ -7,7 +7,7 @@ from scipy import linalg
 from sympy.matrices import Matrix, normalforms
 from sympy import gcd
 
-PRIME_LIST = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 113]
+PRIME_LIST = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]
 RATIONAL_WEIGHT_LIST = ["equilateral"]
 ALGEBRAIC_WEIGHT_LIST = RATIONAL_WEIGHT_LIST + ["wilson", "benedetti"]
 

--- a/te_common.py
+++ b/te_common.py
@@ -7,7 +7,7 @@ from scipy import linalg
 from sympy.matrices import Matrix, normalforms
 from sympy import gcd
 
-PRIME_LIST = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89]
+PRIME_LIST = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 113]
 RATIONAL_WEIGHT_LIST = ["equilateral"]
 ALGEBRAIC_WEIGHT_LIST = RATIONAL_WEIGHT_LIST + ["wilson", "benedetti"]
 
@@ -181,19 +181,18 @@ class Norm:
 
     def __get_interval_weight (self, primes):
         """Returns the weight matrix for a list of formal primes. """
-        match self.wtype:
-            case "tenney":
-                weight_vec = np.log2 (primes)
-            case "wilson" | "benedetti":
-                weight_vec = np.asarray (primes)
-            case "equilateral":
-                weight_vec = np.ones (len (primes))
-            # case "hahn24": #pending better implementation
-            #     weight_vec = np.reciprocal (np.floor (np.log2 (24)/np.log2 (primes)))
-            case _:
-                warnings.warn ("weighter type not supported, using default (\"tenney\")")
-                self.wtype = "tenney"
-                return self.__get_interval_weight (primes)
+        if self.wtype=="tenney":
+            weight_vec = np.log2 (primes)
+        elif self.wtype in ["wilson", "benedetti"]:
+            weight_vec = np.asarray (primes)
+        elif self.wtype=="equilateral":
+            weight_vec = np.ones (len (primes))
+        # elif self.wtype=="hahn24": #pending better implementation
+        #     weight_vec = np.reciprocal (np.floor (np.log2 (24)/np.log2 (primes)))
+        else:
+            warnings.warn ("weighter type not supported, using default (\"tenney\")")
+            self.wtype = "tenney"
+            return self.__get_interval_weight (primes)
         return np.diag (weight_vec**self.wamount)
 
     def __get_tuning_weight (self, primes):
@@ -266,13 +265,12 @@ canonicalise = canonicalize
 
 def __get_length (main, axis):
     """Gets the length along a certain axis."""
-    match axis:
-        case AXIS.ROW:
-            return main.shape[1]
-        case AXIS.COL:
-            return main.shape[0]
-        case AXIS.VEC:
-            return main.size
+    if axis==AXIS.ROW:
+        return main.shape[1]
+    elif axis==AXIS.COL:
+        return main.shape[0]
+    elif axis==AXIS.VEC:
+        return main.size
 
 def get_subgroup (main, axis):
     """Gets the default subgroup along a certain axis."""
@@ -286,13 +284,12 @@ def setup (main, subgroup, axis):
     elif (length_main := __get_length (main, axis)) != len (subgroup):
         warnings.warn ("dimension does not match. Casting to the smaller dimension. ")
         dim = min (length_main, len (subgroup))
-        match axis:
-            case AXIS.ROW:
-                main = main[:, :dim]
-            case AXIS.COL:
-                main = main[:dim, :]
-            case AXIS.VEC:
-                main = main[:dim]
+        if axis==AXIS.ROW:
+            main = main[:, :dim]
+        elif axis==AXIS.COL:
+            main = main[:dim, :]
+        elif axis==AXIS.VEC:
+            main = main[:dim]
         subgroup.basis_matrix = subgroup.basis_matrix[:, :dim]
     return main, subgroup
 

--- a/te_equal.py
+++ b/te_equal.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 import te_common as te
 import te_temperament_measures as te_tm
 
-WARTS_LIST = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
+WARTS_LIST = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y"]
 
 def et_construct (et_list, subgroup):
     """Temperament construction function from equal temperaments."""

--- a/te_equal.py
+++ b/te_equal.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 import te_common as te
 import te_temperament_measures as te_tm
 
-WARTS_LIST = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x"]
+WARTS_LIST = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]
 
 def et_construct (et_list, subgroup):
     """Temperament construction function from equal temperaments."""
@@ -52,18 +52,17 @@ def et_sequence (monzos = None, subgroup = None, ntype = "breed", norm = te.Norm
             if ((not pv or __is_pv (gpv, just_tuning_map)) # patent val or pv isn't set
                     and np.gcd.reduce (gpv) == 1 #not enfactored
                     and not np.any ([gpv] @ monzos)): #tempering out the commas
-                match cond:
-                    case "error":
-                        et = te_tm.Temperament ([gpv], subgroup, saturate = False, normalize = False)
-                        current = et._Temperament__error (ntype, norm, do_inharmonic, te.SCALAR.CENT)
-                    case "badness":
-                        et = te_tm.Temperament ([gpv], subgroup, saturate = False, normalize = False)
-                        current = et._Temperament__badness (ntype, norm, do_inharmonic, te.SCALAR.OCTAVE)
-                    case "logflat badness":
-                        et = te_tm.Temperament ([gpv], subgroup, saturate = False, normalize = False)
-                        current = et._Temperament__badness_logflat (ntype, norm, do_inharmonic, te.SCALAR.OCTAVE)
-                    case _:
-                        current = threshold
+                if cond=="error":
+                    et = te_tm.Temperament ([gpv], subgroup, saturate = False, normalize = False)
+                    current = et._Temperament__error (ntype, norm, do_inharmonic, te.SCALAR.CENT)
+                elif cond=="badness":
+                    et = te_tm.Temperament ([gpv], subgroup, saturate = False, normalize = False)
+                    current = et._Temperament__badness (ntype, norm, do_inharmonic, te.SCALAR.OCTAVE)
+                elif cond=="logflat badness":
+                    et = te_tm.Temperament ([gpv], subgroup, saturate = False, normalize = False)
+                    current = et._Temperament__badness_logflat (ntype, norm, do_inharmonic, te.SCALAR.OCTAVE)
+                else:
+                    current = threshold
                 if current <= threshold:
                     progress_bar.write (f"{te.bra (gpv)} ({breed2warts (gpv, subgroup)})")
                     if prog:

--- a/te_optimizer_legacy.py
+++ b/te_optimizer_legacy.py
@@ -21,17 +21,16 @@ class Norm:
         self.order = order
 
     def __get_tuning_weight (self, subgroup):
-        match self.wtype:
-            case "tenney":
-                weight_vec = np.reciprocal (np.log2 (subgroup, dtype = float))
-            case "wilson" | "benedetti":
-                weight_vec = np.reciprocal (np.array (subgroup, dtype = float))
-            case "equilateral":
-                weight_vec = np.ones (len (subgroup))
-            case _:
-                warnings.warn ("weighter type not supported, using default (\"tenney\")")
-                self.wtype = "tenney"
-                return self.__get_weight (subgroup)
+        if self.wtype=="tenney":
+            weight_vec = np.reciprocal (np.log2 (subgroup, dtype = float))
+        elif self.wtype in ["wilson", "benedetti"]:
+            weight_vec = np.reciprocal (np.array (subgroup, dtype = float))
+        elif self.wtype=="equilateral":
+            weight_vec = np.ones (len (subgroup))
+        else:
+            warnings.warn ("weighter type not supported, using default (\"tenney\")")
+            self.wtype = "tenney"
+            return self.__get_weight (subgroup)
         return np.diag (weight_vec**self.wamount)
 
     def __get_tuning_skew (self, subgroup):

--- a/te_optimizer_legacy.py
+++ b/te_optimizer_legacy.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy import optimize, linalg
 np.set_printoptions (suppress = True, linewidth = 256, precision = 4)
 
-PRIME_LIST = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89]
+PRIME_LIST = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]
 
 class SCALAR:
     CENT = 1200

--- a/te_symbolic.py
+++ b/te_symbolic.py
@@ -18,20 +18,19 @@ class NormSym (te.Norm):
     def __get_interval_weight_sym (self, primes):
         """Returns the weight matrix for a list of formal primes. """
         wamount = Rational (self.wamount).limit_denominator (1e3)
-        match self.wtype:
-            case "tenney":
-                warnings.warn ("transcendental weight can be slow. Main optimizer recommended. ")
-                weight_vec = Matrix (primes).applyfunc (lambda q: log (q, 2))
-            case "wilson" | "benedetti":
-                weight_vec = Matrix (primes)
-            case "equilateral":
-                weight_vec = Matrix.ones (len (primes), 1)
-            # case "hahn24": #pending better implementation
-            #     weight_vec = Matrix (primes).applyfunc (lambda q: 1/floor (log (24, q)))
-            case _:
-                warnings.warn ("weighter type not supported, using default (\"tenney\")")
-                self.wtype = "tenney"
-                return self.__get_interval_weight_sym (primes)
+        if self.wtype=="tenney":
+            warnings.warn ("transcendental weight can be slow. Main optimizer recommended. ")
+            weight_vec = Matrix (primes).applyfunc (lambda q: log (q, 2))
+        elif self.wtype in ["wilson", "benedetti"]:
+            weight_vec = Matrix (primes)
+        elif self.wtype=="equilateral":
+            weight_vec = Matrix.ones (len (primes), 1)
+        # elif self.wtype=="hahn24": #pending better implementation
+        #     weight_vec = Matrix (primes).applyfunc (lambda q: 1/floor (log (24, q)))
+        else:
+            warnings.warn ("weighter type not supported, using default (\"tenney\")")
+            self.wtype = "tenney"
+            return self.__get_interval_weight_sym (primes)
         return Matrix.diag (*weight_vec.applyfunc (lambda wi: Pow (wi, wamount)))
 
     def __get_tuning_weight_sym (self, primes):

--- a/te_temperament_measures.py
+++ b/te_temperament_measures.py
@@ -167,18 +167,17 @@ class Temperament:
             @ norm.tuning_x (mapping, subgroup).T
             )) / index
         # complexity = linalg.norm (self.wedgie (norm = norm)) #same
-        match ntype:
-            case "breed": #Graham Breed's RMS (default)
-                complexity *= 1/np.sqrt (d**r)
-            case "smith": #Gene Ward Smith's RMS
-                complexity *= 1/np.sqrt (len (tuple (itertools.combinations (range (d), r))))
-            case "dirichlet": #Sintel's Dirichlet coefficient
-                complexity *= 1/linalg.det (norm.tuning_x (np.eye (d), subgroup)[:,:d])**(r/d)
-            case "none":
-                pass
-            case _:
-                warnings.warn ("normalizer not supported, using default (\"breed\")")
-                return self.__complexity (ntype = "breed", norm = norm, inharmonic = inharmonic)
+        if ntype=="breed": #Graham Breed's RMS (default)
+            complexity *= 1/np.sqrt (d**r)
+        elif ntype=="smith": #Gene Ward Smith's RMS
+            complexity *= 1/np.sqrt (len (tuple (itertools.combinations (range (d), r))))
+        elif ntype=="dirichlet": #Sintel's Dirichlet coefficient
+            complexity *= 1/linalg.det (norm.tuning_x (np.eye (d), subgroup)[:,:d])**(r/d)
+        elif ntype=="none":
+            pass
+        else:
+            warnings.warn ("normalizer not supported, using default (\"breed\")")
+            return self.__complexity (ntype = "breed", norm = norm, inharmonic = inharmonic)
         return complexity
 
     def __error (self, ntype, norm, inharmonic, scalar):
@@ -198,22 +197,21 @@ class Temperament:
             @ norm.tuning_x (mapping, subgroup)
             - norm.tuning_x (just_tuning_map, subgroup)
         )
-        match ntype: 
-            case "breed": #Graham Breed's RMS (default)
-                error *= 1/np.sqrt (d)
-            case "smith": #Gene Ward Smith's RMS
-                try:
-                    error *= np.sqrt ((r + 1)/(d - r))
-                except ZeroDivisionError:
-                    error = np.nan
-            case "dirichlet": #Sintel's Dirichlet coefficient
-                error *= 1/(np.sqrt (d)
-                    * linalg.det (norm.tuning_x (np.eye (d), subgroup)[:,:d])**(1/d))
-            case "none":
-                pass
-            case _:
-                warnings.warn ("normalizer not supported, using default (\"breed\")")
-                return self.__error ("breed", norm, inharmonic, scalar)
+        if ntype=="breed": #Graham Breed's RMS (default)
+            error *= 1/np.sqrt (d)
+        elif ntype=="smith": #Gene Ward Smith's RMS
+            try:
+                error *= np.sqrt ((r + 1)/(d - r))
+            except ZeroDivisionError:
+                error = np.nan
+        elif ntype=="dirichlet": #Sintel's Dirichlet coefficient
+            error *= 1/(np.sqrt (d)
+                * linalg.det (norm.tuning_x (np.eye (d), subgroup)[:,:d])**(1/d))
+        elif ntype=="none":
+            pass
+        else:
+            warnings.warn ("normalizer not supported, using default (\"breed\")")
+            return self.__error ("breed", norm, inharmonic, scalar)
         return error
 
     def badness (self, ntype = "breed", norm = te.Norm (), inharmonic = False, 
@@ -241,15 +239,14 @@ class Temperament:
                 * self.__complexity (ntype, norm, inharmonic)**(d/(d - r)))
         except ZeroDivisionError:
             res = np.nan
-        match ntype:
-            case "dirichlet":
-                norm_jtm = 1/linalg.det (norm.tuning_x (np.eye (d), self.subgroup)[:,:d])**(1/d)
-                res /= norm_jtm
-            case "breed" | "smith" | "none":
-                pass
-            case _:
-                warnings.warn ("normalizer not supported, using default (\"breed\")")
-                return self.__badness_logflat ("breed", norm, inharmonic, scalar)
+        if ntype=="dirichlet":
+            norm_jtm = 1/linalg.det (norm.tuning_x (np.eye (d), self.subgroup)[:,:d])**(1/d)
+            res /= norm_jtm
+        elif ntype in ["breed", "smith", "none"]:
+            pass
+        else:
+            warnings.warn ("normalizer not supported, using default (\"breed\")")
+            return self.__badness_logflat ("breed", norm, inharmonic, scalar)
         return res
 
     def temperament_measures (self, ntype = "breed", norm = te.Norm (), inharmonic = False, 


### PR DESCRIPTION
specifically, i change all the instances of `match` to plain `if:` `elif:` (`else:`). i also increased the maximum prime to 97, as 97/64 is approximated extremely well in a very small EDO (5 EDO specifically, with only 0.1 cent error) but also as 89 is the start of a record prime gap that ends at prime 97, so it'd be nice to include for that reason too.

this also has the effect of reducing the amount of indents in the code and shortening the code (both in terms of line and character count) while being at least equally as readable (though in my subjective opinion it's more readable).

edit: also, make sure to view all changes, as i mistakenly added prime 113 after prime 97 in the PRIME_LIST but i did fix it in a later edit.